### PR TITLE
Add specific API references to Google API key declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current Weather is provided by [climacell.co](https://www.climacell.co/weather-a
 
 Radar imgages are provided by [Iowa State Mesonet](http://mesonet.agron.iastate.edu/GIS/ridge.phtml)
 
-Maps provided by [Google](http://google.com) - Maps API key required
+Maps provided by [Google](http://google.com) - [API Key](https://console.cloud.google.com) required with permissions for Maps Static API and Maps JavaScript API
 
 Forecast headlines and details provided by [NOAA](https://www.weather.gov/)
 


### PR DESCRIPTION
It took me a while to figure out why my maps were going blank when I had Maps Static API enabled.  This project uses Maps Static and JavaScript APIs. 